### PR TITLE
Update package to julia 1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.aux
 *.log
 *.pdf
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ os:
   - linux
   - osx
 julia:
+  - 1.0
+  - 1.2
   - nightly
+matrix:
+  allow_failures:
+    - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "FFTViews"
+uuid = "4f61f5a4-77b1-5117-aa51-3ab5ef4ef0cd"
+version = "0.3.0"
+
+[deps]
+CustomUnitRanges = "dc8bdbbb-1ca9-579f-8c36-e416f6a65cce"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+
+[compat]
+julia = "1"
+
+[extras]
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["OffsetArrays", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7.0-beta
-CustomUnitRanges
-FFTW

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-OffsetArrays 0.8


### PR DESCRIPTION
I met an incompatibility error in https://travis-ci.org/johnnychen94/DemoCards.jl/jobs/584132372#L278-L306 where `ReferenceTests` requires `Images`, and `Images` requires `ImageFiltering` requiring `FFTViews`.

in `General/FFTViews/compat.toml`, FFTW is restricted to "0". However, FFTW is tagged a `1.0` version 10 days ago https://github.com/JuliaMath/FFTW.jl/commit/5c3d4a38b5f1d3d0c3680e895bccb2b19622d38c
```
["0.1-0"]
FFTW = "0"
```

Although we could fix the error in General, it's better to adopt the package registrator system

P.S. 

* The last time CI runs is one year ago, I think it's better to make a cron job on travis.
* Looks like appveyor isn't working, so I didn't change it.