### PR TITLE
fix dispatching error by adding IdentiyUnitRange to FFTVRange

### DIFF
--- a/src/FFTViews.jl
+++ b/src/FFTViews.jl
@@ -18,7 +18,7 @@ Base.checkindex(::Type{Bool}, inds::URange, ::AbstractVector{Bool}) = true
 Base.checkindex(::Type{Bool}, inds::URange, ::AbstractArray{Bool}) = true
 Base.checkindex(::Type{Bool}, inds::URange, ::AbstractArray) = true
 
-const FFTVRange{T} = Union{URange{T}, Base.Slice{URange{T}}}
+const FFTVRange{T} = Union{URange{T}, Base.Slice{URange{T}}, Base.IdentityUnitRange{URange{T}}}
 
 export FFTView
 


### PR DESCRIPTION
Cont. #12 

`a[0, :]` breaks in julia `v1.1` and `v1.2` because `similar` in `FFTViews` doesn't work (the range type changes somehow), this PR fixes this.

https://github.com/JuliaArrays/FFTViews.jl/blob/371122337716cb0be7875a5de5273dd2ee117b59/src/FFTViews.jl#L55-L63

There's still one error which I'm not sure of:

```julia
@test a[3,trues(9)] == [9,14,19,24,29,34,4,9,14] # line 36
@test a[3,FFTView(trues(9))] == [4,9,14,19,24,29,34,4,9] # line 37

Test Failed at /Users/jc/Documents/Julia/FFTViews.jl/test/runtests.jl:37
  Expression: a[3, FFTView(trues(9))] == [4, 9, 14, 19, 24, 29, 34, 4, 9]
   Evaluated: [9.0, 14.0, 19.0, 24.0, 29.0, 34.0, 4.0, 9.0, 14.0] == [4, 9, 14, 19, 24, 29, 34, 4, 9]
```