### PR TITLE
make explicit that axes comparisons in tests ignore indices

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ else
     const _oneunit = Base.oneunit
 end
 
+axes_values(x, d) = values(axes(x, d))
+axes_values(x) = map(values, axes(x))
+
 function test_approx_eq_periodic(a::FFTView, b)
     for I in CartesianIndices(axes(b))
         @test a[I-_oneunit(I)] ≈ b[I]
@@ -27,10 +30,10 @@ end
 
 @testset "basics" begin
     a = FFTView{Float64,2}((5,7))
-    @test axes(a) == (0:4, 0:6)
+    @test axes_values(a) == (0:4, 0:6)
     @test eltype(a) == Float64
     a = FFTView{Float64}((5,7))
-    @test axes(a) == (0:4, 0:6)
+    @test axes_values(a) == (0:4, 0:6)
     @test eltype(a) == Float64
     @test_throws MethodError FFTView{Float64,3}((5,7))
     for i = 1:35
@@ -49,14 +52,14 @@ end
     @test eltype(b) == Int
     @test reshape(a, Val{2}) === a
     @test reshape(a, Val{1}) == FFTView(convert(Vector{Float64}, collect(1:35)))
-    @test axes(reshape(a, Val{3})) == (0:4,0:6,0:0)
+    @test axes_values(reshape(a, Val{3})) == (0:4,0:6,0:0)
 end
 
 @testset "convolution-shift" begin
     for l in (8,9)
         a = zeros(l)
         v = FFTView(a)
-        @test axes(v,1) == 0:l-1
+        @test axes_values(v,1) == 0:l-1
         v[0] = 1
         p = rand(l)
         pfilt = ifft(fft(p).*fft(v))
@@ -73,7 +76,7 @@ end
     for l2 in (8,9), l1 in (8,9)
         a = zeros(l1,l2)
         v = FFTView(a)
-        @test axes(v) == (0:l1-1, 0:l2-1)
+        @test axes_values(v) == (0:l1-1, 0:l2-1)
         p = rand(l1,l2)
         for offset in ((0,0), (-1,0), (0,-1), (-1,-1),
                        (1,0), (0,1), (1,1), (1,-1), (-1,1),
@@ -92,7 +95,7 @@ using OffsetArrays
     for l2 in (8,9), l1 in (8,9)
         a = OffsetArray(zeros(l1,l2), (-2,-3))
         v = FFTView(a)
-        @test axes(v) == (-2:l1-3, -3:l2-4)
+        @test axes_values(v) == (-2:l1-3, -3:l2-4)
         p = rand(l1,l2)
         po = OffsetArray(copy(p), (5,-1))
         for offset in ((0,0), (-1,0), (0,-1), (-1,-1),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,9 @@ else
     const _oneunit = Base.oneunit
 end
 
-axes_values(x, d) = values(axes(x, d))
-axes_values(x) = map(values, axes(x))
+values1(r) = first(r):last(r)   # ensure 1-based indices
+axes_values(x, d) = values1(axes(x, d))
+axes_values(x) = map(values1, axes(x))
 
 function test_approx_eq_periodic(a::FFTView, b)
     for I in CartesianIndices(axes(b))


### PR DESCRIPTION
This PR was suggested by @nsajko in https://github.com/JuliaLang/julia/pull/54825. Currently Julia compares ranges only by comparing their values, not their indices, although they should also be taken into account for `AbstractVector`. The tests in FFTViews.jl rely on this special behavior. This PR makes this explicit.

EDIT: title and the text reworded